### PR TITLE
Adding data paths

### DIFF
--- a/js/parse.js
+++ b/js/parse.js
@@ -6,7 +6,11 @@ var currentMon = 0;
 var dataUrls = {
   "2":"https://jake-white.github.io/VGC-Battlespot-Usage/Data-2/",
   "3":"https://jake-white.github.io/VGC-Battlespot-Usage/Data-3/",
-  "ICFeb":"https://jake-white.github.io/VGC-Battlespot-Usage/Data-ICFeb/"
+  "ICFeb":"https://jake-white.github.io/VGC-Battlespot-Usage/Data-ICFeb/",
+  "4":"https://Razator73.github.io/VGC-Battlespot-Usage/Data-4/",
+  "ICApr":"https://Razator73.github.io/VGC-Battlespot-Usage/Data-ICApr/",
+  "ICMay":"https://Razator73.github.io/VGC-Battlespot-Usage/Data-ICMay/",
+  "5":"https://Razator73.github.io/VGC-Battlespot-Usage/Data-5/"
 }
 
 var formes = {"porygon-z":"474",


### PR DESCRIPTION
Hey, 

I cloned this repository to practice web scraping as I am teaching myself programming. If you'd like I have added the urls to my cloned repository that include some more of the recent data. This includes season 4 end data and the April and May ICs. It also has the Season 5 data as of this morning (2017/07/19). 

If you don't want to use the links to the updated data that's ok.